### PR TITLE
fix parallel flag and Run waitgroup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: go
+go:
+  - 1.8
+install:
+  - go get github.com/constabulary/gb/...
+  - ./vendor.sh
+script:
+  - ./test.sh
+notifications:
+  email: false
+sudo: false
+

--- a/README.md
+++ b/README.md
@@ -8,11 +8,24 @@ This functions just like rsync and will monitor for new files and immediately sy
 
 ```
 Usage of ./lives3syncd:
-  -bucket="": S3 bucket name
-  -prefix="": A directory prefix for prepended to uploads
-  -src="": directory to monitor for new files
-  -dry-run=false: log intended actions without initiating any copies
-  -run-once=false: exit after a single sync pace
+  -bucket string
+    	S3 bucket name
+  -dry-run
+    	dry run only - don't upload files
+  -exclude value
+    	pattern to exclude (may be given multiple times. Multiple patterns OR'd together)
+  -match value
+    	pattern to match (may be given multiple times. Multiple patterns OR'd together)
+  -parallel int
+    	parallel uploads (defaults to number of available cores)
+  -prefix string
+    	prefix for content in s3
+  -region string
+    	AWS S3 Region (default "us-east-1")
+  -run-once
+    	exit after syncing existing files (ie: don't wait for updates)
+  -src string
+    	source directory to sync
 ```
 
 ## Configuring S3 Credentials

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 lives3syncd
 -----------
 
+[![Build Status](https://secure.travis-ci.org/jehiah/lives3sync.svg?branch=master)](http://travis-ci.org/jehiah/lives3sync)
+
 Continually sync a local filesystem to S3.
 
 This functions just like rsync and will monitor for new files and immediately sync them to S3. Multiple uploads to S3 are handled concurrently, and large files are chunked.

--- a/dist.sh
+++ b/dist.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# build binary distributions for linux/amd64 and darwin/amd64
+set -e 
+
+APP=lives3syncd
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+echo "working dir $DIR"
+
+rm -rf $DIR/vendor
+echo "... refreshing vendor directory"
+./vendor.sh
+
+echo "... running tests"
+./test.sh || exit 1
+
+arch=$(go env GOARCH)
+version=$(cat $DIR/src/cmd/$APP/version.go | grep "const VERSION" | awk '{print $NF}' | sed 's/"//g')
+goversion=$(go version | awk '{print $3}')
+
+mkdir -p dist
+for os in linux darwin; do
+    echo "... building v$version for $os/$arch"
+    BUILD=$(mktemp -d -t sortdb)
+    TARGET="$APP-$version.$os-$arch.$goversion"
+    GOOS=$os GOARCH=$arch CGO_ENABLED=0 gb build
+    mkdir -p $BUILD/$TARGET
+    cp bin/$APP-$os-$arch $BUILD/$TARGET/$APP
+    pushd $BUILD >/dev/null
+    tar czvf $TARGET.tar.gz $TARGET
+    if [ -e $DIR/dist/$TARGET.tar.gz ]; then
+        echo "... WARNING overwriting dist/$TARGET.tar.gz"
+    fi
+    mv $TARGET.tar.gz $DIR/dist
+    echo "... built dist/$TARGET.tar.gz"
+    popd >/dev/null
+done

--- a/src/cmd/lives3syncd/lives3syncd.go
+++ b/src/cmd/lives3syncd/lives3syncd.go
@@ -25,6 +25,7 @@ func main() {
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 	s := NewSync()
 
+	showVersion := flag.Bool("version", false, "print version string")
 	flag.StringVar(&s.Bucket, "bucket", "", "S3 bucket name")
 	flag.StringVar(&s.Src, "src", "", "source directory to sync")
 	flag.StringVar(&s.Prefix, "prefix", "", "prefix for content in s3")
@@ -38,6 +39,11 @@ func main() {
 	parallelUploads := flag.Int("parallel", runtime.NumCPU(), "parallel uploads (defaults to number of available cores)")
 
 	flag.Parse()
+
+	if *showVersion {
+		fmt.Printf("lives3syncd v%s (built w/%s)\n", VERSION, runtime.Version())
+		return
+	}
 
 	if *parallelUploads < 1 {
 		log.Fatalf("Invalid setting for parallel (%d). Must be >= 1", *parallelUploads)

--- a/src/cmd/lives3syncd/lives3syncd.go
+++ b/src/cmd/lives3syncd/lives3syncd.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"path"
 	"runtime"
 	"sync"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 )
 
@@ -60,9 +62,13 @@ func main() {
 		log.Fatalf("bucket name required")
 	}
 
-	s.S3 = s3.New(&aws.Config{
-		Region: *region,
-	})
+	s.sess = session.Must(session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+		Config: aws.Config{
+			Region: region,
+		},
+	}))
+	s.S3 = s3.New(s.sess)
 
 	var wg sync.WaitGroup
 	log.Printf("Starting %d Concurrent Upload Threads", *parallelUploads)

--- a/src/cmd/lives3syncd/lives3syncd.go
+++ b/src/cmd/lives3syncd/lives3syncd.go
@@ -35,9 +35,13 @@ func main() {
 	flag.Var(&s.Exclude, "exclude", "pattern to exclude (may be given multiple times. Multiple patterns OR'd together)")
 
 	region := flag.String("region", "us-east-1", "AWS S3 Region")
-	parallelUploads := flag.Int("prallel", runtime.NumCPU(), "paralell uploads (defaults to number of available cores)")
+	parallelUploads := flag.Int("parallel", runtime.NumCPU(), "parallel uploads (defaults to number of available cores)")
 
 	flag.Parse()
+	
+	if *parallelUploads < 1 {
+		log.Fatalf("Invalid setting for parallel (%d). Must be >= 1", *parallelUploads)
+	}
 
 	if err := validatePatterns(s.Match...); err != nil {
 		log.Fatalf("Invalid Pattern: %s", err)

--- a/src/cmd/lives3syncd/lives3syncd.go
+++ b/src/cmd/lives3syncd/lives3syncd.go
@@ -38,7 +38,7 @@ func main() {
 	parallelUploads := flag.Int("parallel", runtime.NumCPU(), "parallel uploads (defaults to number of available cores)")
 
 	flag.Parse()
-	
+
 	if *parallelUploads < 1 {
 		log.Fatalf("Invalid setting for parallel (%d). Must be >= 1", *parallelUploads)
 	}
@@ -65,6 +65,7 @@ func main() {
 		go s.Uploader(&wg)
 	}
 
+	wg.Add(1)
 	s.Run(&wg)
 	wg.Wait()
 }

--- a/src/cmd/lives3syncd/sync.go
+++ b/src/cmd/lives3syncd/sync.go
@@ -41,7 +41,7 @@ func NewSync() *Sync {
 	s := &Sync{
 		queue:        make(chan *PendingSync, 100),
 		pending:      make(map[string]*PendingSync),
-		upload:       make(chan *PendingSync),
+		upload:       make(chan *PendingSync, 1),
 		uploadNotify: make(chan bool, 1),
 		exitChan:     make(chan bool),
 	}

--- a/src/cmd/lives3syncd/sync.go
+++ b/src/cmd/lives3syncd/sync.go
@@ -10,12 +10,14 @@ import (
 	"sync"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/service/s3"
 )
 
 type Sync struct {
 	Bucket  string
 	S3      *s3.S3
+	sess    client.ConfigProvider
 	Src     string
 	Prefix  string
 	DryRun  bool

--- a/src/cmd/lives3syncd/upload.go
+++ b/src/cmd/lives3syncd/upload.go
@@ -84,9 +84,8 @@ func (s *Sync) Upload(entry *PendingSync) error {
 		return nil
 	}
 
-	uploader := s3manager.NewUploader(&s3manager.UploadOptions{
-		S3:       s.S3,
-		PartSize: 1024 * 1024 * 10,
+	uploader := s3manager.NewUploader(s.sess, func(u *s3manager.Uploader) {
+		u.PartSize = 64 * 1024 * 1024 // 64MB per part
 	})
 
 	resp, err := uploader.Upload(&s3manager.UploadInput{

--- a/src/cmd/lives3syncd/upload.go
+++ b/src/cmd/lives3syncd/upload.go
@@ -73,7 +73,7 @@ func (s *Sync) Upload(entry *PendingSync) error {
 			return nil
 		}
 	} else {
-		return err
+		return fmt.Errorf("error checking HEAD %s %s", s3Location, err)
 	}
 
 	log.Printf("[%d] uploading %q => %s size:%d bytes", entry.Sequence, entry.Name, s3Location, size)

--- a/src/cmd/lives3syncd/version.go
+++ b/src/cmd/lives3syncd/version.go
@@ -1,0 +1,3 @@
+package main
+
+const VERSION = "0.1.0"

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+gb test -timeout 60s
+# gb test -timeout 60s -race
+gb build

--- a/vendor.sh
+++ b/vendor.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
-gb vendor fetch -tag v0.6.4 github.com/aws/aws-sdk-go/aws
-gb vendor fetch -tag v0.6.4 github.com/aws/aws-sdk-go/service/s3
+if [ -e vendor ]; then
+    echo "vendor folder already exists"
+    exit 1
+fi
+
+gb vendor fetch -tag v1.10.14 github.com/aws/aws-sdk-go/aws
+gb vendor fetch -tag v1.10.14 github.com/aws/aws-sdk-go/service/s3
 gb vendor fetch -revision a98ad7ee00ec53921f08832bc06ecf7fd600e6a1 github.com/vaughan0/go-ini
 gb vendor fetch -tag v0.9.3 gopkg.in/fsnotify.v0


### PR DESCRIPTION
This adds a missing wg.Add before the Run goroutine, and fixes the -parallel argument. This also gives a better output for HEAD errors that might be due to missing GetObject permission.