### PR TITLE
-base, -include-hidden options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor
 pkg
 bin
+dist

--- a/README.md
+++ b/README.md
@@ -9,17 +9,21 @@ This functions just like rsync and will monitor for new files and immediately sy
 
 
 ```
-Usage of ./lives3syncd:
+Usage of lives3syncd:
+  -base
+    	apply 'match' and 'exclude' against the file base name not the full path
   -bucket string
     	S3 bucket name
   -dry-run
     	dry run only - don't upload files
   -exclude value
     	pattern to exclude (may be given multiple times. Multiple patterns OR'd together)
+  -ignore-hidden
+    	ignore hidden files (i.e. dot files)
   -match value
     	pattern to match (may be given multiple times. Multiple patterns OR'd together)
   -parallel int
-    	parallel uploads (defaults to number of available cores)
+    	parallel uploads (defaults to number of available cores) (default 8)
   -prefix string
     	prefix for content in s3
   -region string
@@ -28,6 +32,8 @@ Usage of ./lives3syncd:
     	exit after syncing existing files (ie: don't wait for updates)
   -src string
     	source directory to sync
+  -version
+    	print version string
 ```
 
 ## Configuring S3 Credentials

--- a/src/cmd/lives3syncd/pending.go
+++ b/src/cmd/lives3syncd/pending.go
@@ -12,6 +12,8 @@ type PendingSync struct {
 	Sequence uint64
 	Attempts int
 
+	Uploaded bool
+
 	// The heap index is needed by update and is maintained by the heap.Interface methods.
 	index int
 }

--- a/src/cmd/lives3syncd/version.go
+++ b/src/cmd/lives3syncd/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.1.0"
+const VERSION = "0.1.1.alpha"


### PR DESCRIPTION
This adds a configurable to apply `match` and `exclude` against the qualified filename instead of the filename base, and this makes configurable the option to skip hidden files